### PR TITLE
Avoid destructive walking

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -120,9 +120,7 @@ def walk(x, action, format, meta):
                 array.append(walk(item, action, format, meta))
         return array
     elif isinstance(x, dict):
-        for k in x:
-            x[k] = walk(x[k], action, format, meta)
-        return x
+        return {k: walk(v, action, format, meta) for k, v in x.items()}
     else:
         return x
 


### PR DESCRIPTION
I've been invoking the `walk` method multiple times on the same tree object, and I've realized that it destroys the tree in the process, by overwriting dictionary values. Since `walk` is not destructive on anything but dictionaries, I'm assuming that this is not intentional. The fix is rather tiny: create a new dictionary instead of modifying the old one.

Never imagined finding a bug like this in such a wonderfully functional project ;-)